### PR TITLE
Added systemctl dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX ?= /usr/local
 
 BREAD_SERVICE_NAME = bbbread
 BREAD_SRC_SERVICE_FILE = ${BREAD_SERVICE_NAME}.service
-
+BREAD_DEPENDENCIES = systemd-networkd systemd-networkd-wait-online
 SERVICE_FILE_DEST = /etc/systemd/system
 
 .PHONY: all install uninstall dependencies clean docker
@@ -16,6 +16,10 @@ install:
 #	python-sirius -m pip install -r requirements.txt
 
 	systemctl daemon-reload
+
+	# enable and start dependencies
+	systemctl enable ${BREAD_DEPENDENCIES}
+	systemctl start ${BREAD_DEPENDENCIES}
 
 	systemctl restart ${BREAD_SERVICE_NAME}
 	systemctl enable ${BREAD_SERVICE_NAME}


### PR DESCRIPTION
This PR fixes the bug that caused the bbbread service start before the network is fully up. Although the bbbread service includes the line `Wants=network-online.target`, we empirically verified that it only works if both `systemd-networkd` AND `systemd-networkd-wait-online` services are enabled, which is not the case by default in the current image.

Since other applications (like bbb-function) may also need this fix, I suggest adding it at a lower level instance in the image.